### PR TITLE
test: deprecate `import` in favor of `require`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const octokit = new Octokit();
 
 async function createChatGPTAPI(sessionToken) {
   // To use ESM in CommonJS, you can use a dynamic import
-  const { ChatGPTAPI } = await import("chatgpt");
+  const { ChatGPTAPI } = await require("chatgpt");
 
   const api = new ChatGPTAPI({ sessionToken });
 


### PR DESCRIPTION
Use CJS require instead of import. Why? I love CommonJS!