### PR TITLE
refactor: move creation of octokit to run.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const core = require("@actions/core");
 const github = require("@actions/github");
-const { Octokit } = require("@octokit/action");
-const octokit = new Octokit();
+
 const { createChatGPTAPI } = require("./chatgpt");
 const { runPRReview } = require("./run");
 
@@ -20,7 +19,7 @@ async function run() {
     const api = await createChatGPTAPI(sessionToken);
 
     if (mode == "pr") {
-      runPRReview({ octokit, api, owner, repo, number, context });
+      runPRReview({ api, owner, repo, number, context });
     } else if (mode == "issue") {
       throw "Not implemented!";
     } else {

--- a/run.js
+++ b/run.js
@@ -1,8 +1,10 @@
 const core = require("@actions/core");
 const { genReviewPRPrompt } = require("./prompt");
 const { callChatGPT } = require("./chatgpt");
+const { Octokit } = require("@octokit/action");
+const octokit = new Octokit();
 
-async function runPRReview({ octokit, api, repo, owner, number, context }) {
+async function runPRReview({ api, repo, owner, number, context }) {
   const {
     data: { title, body },
   } = await octokit.pulls.get({


### PR DESCRIPTION
To simplify the parameter of `runPRReview `, I moved creation of octokit to run.js.